### PR TITLE
provide the ability to pass in an external signature provider

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,7 @@ class Orejs {
   constructEos(config) {
     this.config = config;
     const rpc = new eosjs.JsonRpc(config.httpEndpoint, { fetch: config.fetch || fetch });
-    const signatureProvider = new eosjs.JsSignatureProvider(config.keyProvider || []);
+    const signatureProvider = config.signatureProvider || new eosjs.JsSignatureProvider(config.keyProvider || []);
     this.eos = new eosjs.Api({ chainId: config.chainId, rpc, signatureProvider, textEncoder: new TextEncoder(), textDecoder: new TextDecoder() });
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -31,9 +31,15 @@ class Orejs {
 
   constructEos(config) {
     this.config = config;
-    const rpc = new eosjs.JsonRpc(config.httpEndpoint, { fetch: config.fetch || fetch });
-    const signatureProvider = config.signatureProvider || new eosjs.JsSignatureProvider(config.keyProvider || []);
-    this.eos = new eosjs.Api({ chainId: config.chainId, rpc, signatureProvider, textEncoder: new TextEncoder(), textDecoder: new TextDecoder() });
+    this.rpc = new eosjs.JsonRpc(config.httpEndpoint, { fetch: config.fetch || fetch });
+    this.signatureProvider = config.signatureProvider || new eosjs.JsSignatureProvider(config.privateKeys || []);
+    this.eos = new eosjs.Api({
+      chainId: config.chainId,
+      rpc: this.rpc,
+      signatureProvider: this.signatureProvider,
+      textEncoder: new TextEncoder(),
+      textDecoder: new TextDecoder()
+    });
   }
 }
 

--- a/src/verifier.js
+++ b/src/verifier.js
@@ -4,7 +4,12 @@ const ecc = require('eosjs-ecc')
 
 // sign the input data with the user keys
 async function sign(data) {
-    return ecc.sign(data.toString(), this.config.keyProvider[0]);
+    try {
+        return ecc.sign(data.toString(), this.config.privateKeys[0]);
+    } catch(error) {
+        errorTitle = "Orejs Verifier Sign Error";
+        throw new Error(`${errorTitle}: ${error.message}`);
+    }
 }
 
 // hash the parameter values to be sent to the verifier


### PR DESCRIPTION
This gives us, or anyone using ore-js the ability to pass in a signature provider of their choosing. However, we must remember to refrain from doing so in our client-side code, as the private keys are held, unencrypted, within the SIgnatureProvider.